### PR TITLE
Add custom package page

### DIFF
--- a/Editor/UI/Actions.cs
+++ b/Editor/UI/Actions.cs
@@ -61,8 +61,7 @@ namespace DUCK.PackageManager.Editor.UI
 
 			var taskChain = new TaskChain();
 
-			taskChain.Add(
-				new AddSubmoduleTask(package.GitUrl, relativeInstallDirectory));
+			taskChain.Add(new AddSubmoduleTask(package.GitUrl, relativeInstallDirectory));
 
 			taskChain.Add(new CheckoutSubmoduleTask(absoluteInstallDirectory, version));
 
@@ -87,21 +86,18 @@ namespace DUCK.PackageManager.Editor.UI
 
 			var taskChain = new TaskChain();
 
-			taskChain.Add(
-				new AddSubmoduleTask(url, relativeInstallDirectory));
+			taskChain.Add(new AddSubmoduleTask(url, relativeInstallDirectory));
 
 			if (!string.IsNullOrEmpty(version))
 			{
 				taskChain.Add(new CheckoutSubmoduleTask(absoluteInstallDirectory, version));
 			}
 
-			taskChain.Execute(() =>
-			{
-				Dispatcher.Dispatch(ActionTypes.PACKAGE_INSTALLATION_COMPLETE, args);
-			});
+			taskChain.Execute(() => { Dispatcher.Dispatch(ActionTypes.PACKAGE_INSTALLATION_COMPLETE, args); });
 
 			// TODO: handle errors
 		}
+
 		public static void RemovePackage(AvailablePackage package)
 		{
 			var installDirectory = Settings.RelativePackagesDirectoryPath + package.Name;

--- a/Editor/UI/Components/AddCustomPackage/AddCustomPackagePage.cs
+++ b/Editor/UI/Components/AddCustomPackage/AddCustomPackagePage.cs
@@ -13,6 +13,7 @@ namespace DUCK.PackageManager.Editor.UI.Components.AddCustomPackage
 	{
 		private TextField nameInput;
 		private TextField urlInput;
+		private TextField versionInput;
 		private Label errorLabel;
 
 		public AddCustomPackagePage()
@@ -33,6 +34,13 @@ namespace DUCK.PackageManager.Editor.UI.Components.AddCustomPackage
 			urlInput.style.Padding(4);
 			urlInput.style.fontSize = FontSizes.textInput;
 
+			var versionLabel = new Label("Version (Optional) (Git tag or branch)");
+			versionLabel.style.marginTop = 4;
+			versionInput = new TextField();
+			versionInput.style.Margin(4);
+			versionInput.style.Padding(4);
+			versionInput.style.fontSize = FontSizes.textInput;
+
 			errorLabel = new Label();
 			errorLabel.style.marginTop = 4;
 			errorLabel.style.marginBottom = 4;
@@ -47,6 +55,8 @@ namespace DUCK.PackageManager.Editor.UI.Components.AddCustomPackage
 			Add(nameInput);
 			Add(urlLabel);
 			Add(urlInput);
+			Add(versionLabel);
+			Add(versionInput);
 			Add(errorLabel);
 			Add(addButton);
 		}
@@ -87,7 +97,7 @@ namespace DUCK.PackageManager.Editor.UI.Components.AddCustomPackage
 			}
 
 			// If we get to here we can install
-			Actions.InstallCustomPackage(name, url);
+			Actions.InstallCustomPackage(name, url, versionInput.value);
 		}
 	}
 }

--- a/Editor/UI/Components/AddCustomPackage/AddCustomPackagePage.cs
+++ b/Editor/UI/Components/AddCustomPackage/AddCustomPackagePage.cs
@@ -87,6 +87,7 @@ namespace DUCK.PackageManager.Editor.UI.Components.AddCustomPackage
 			}
 
 			// If we get to here we can install
+			Actions.InstallCustomPackage(name, url);
 		}
 	}
 }

--- a/Editor/UI/Components/AddCustomPackage/AddCustomPackagePage.cs
+++ b/Editor/UI/Components/AddCustomPackage/AddCustomPackagePage.cs
@@ -1,5 +1,9 @@
-﻿using DUCK.PackageManager.Editor.UI.Styles;
+﻿using System.Linq;
+using DUCK.PackageManager.Editor.UI.Stores;
+using DUCK.PackageManager.Editor.UI.Styles;
 using DUCK.PackageManager.Editor.UI.Utils;
+using UnityEditor.Timeline;
+using UnityEngine;
 using UnityEngine.Experimental.UIElements;
 using UnityEngine.Experimental.UIElements.StyleEnums;
 
@@ -7,23 +11,31 @@ namespace DUCK.PackageManager.Editor.UI.Components.AddCustomPackage
 {
 	public class AddCustomPackagePage : VisualElement
 	{
+		private TextField nameInput;
+		private TextField urlInput;
+		private Label errorLabel;
+
 		public AddCustomPackagePage()
 		{
 			style.flex = 1;
 			style.paddingTop = 16;
 
 			var nameField = new Label("Package Name (Can be anything as long as it's unique)");
-			var nameInput = new TextField();
+			nameInput = new TextField();
 			nameInput.style.Margin(4);
 			nameInput.style.Padding(4);
 			nameInput.style.fontSize = FontSizes.textInput;
 
-			var urlLabel = new Label("Git URL");
+			var urlLabel = new Label("Git URL (Must be https)");
 			urlLabel.style.marginTop = 4;
-			var urlInput = new TextField();
+			urlInput = new TextField();
 			urlInput.style.Margin(4);
 			urlInput.style.Padding(4);
 			urlInput.style.fontSize = FontSizes.textInput;
+
+			errorLabel = new Label();
+			errorLabel.style.marginTop = 4;
+			errorLabel.style.marginBottom = 4;
 
 			var addButton = new Button(HandleAddButtonClicked);
 			addButton.text = "Add";
@@ -35,13 +47,46 @@ namespace DUCK.PackageManager.Editor.UI.Components.AddCustomPackage
 			Add(nameInput);
 			Add(urlLabel);
 			Add(urlInput);
+			Add(errorLabel);
 			Add(addButton);
-
-			Add(new Overlay(new LoadingIndicator("Coming Soon")));
 		}
 
 		private void HandleAddButtonClicked()
 		{
+			// clear error
+			errorLabel.text = "";
+
+			var name = nameInput.value;
+			var url = urlInput.value;
+
+			if (string.IsNullOrEmpty(name))
+			{
+				errorLabel.text = "Error! Package name cannot be empty";
+				return;
+			}
+
+			var installedPackages = RootStore.Instance.Packages.InstalledPackages;
+			// name must not be already used by another installed package
+			if (installedPackages.Value.Packages.Any(p => p.Name == name))
+			{
+				errorLabel.text = "Error! A package with this name already exists";
+				return;
+			}
+
+			if (string.IsNullOrEmpty(url))
+			{
+				errorLabel.text = "Error! Git url cannot be empty";
+				return;
+			}
+
+			// url must start with https and end
+			if (!url.StartsWith("https://") || !url.EndsWith(".git"))
+			{
+				errorLabel.text = "Error! git url must be a https git url";
+				return;
+			}
+
+			// If we get to here we can install
 		}
 	}
 }

--- a/Editor/UI/Stores/PackageStore.cs
+++ b/Editor/UI/Stores/PackageStore.cs
@@ -74,8 +74,7 @@ namespace DUCK.PackageManager.Editor.UI.Stores
 			var args = (InstallPackageArgs) obj.Payload;
 
 			var installedPackages = InstalledPackages.Value;
-			installedPackages.Packages.Add(
-				new InstalledPackage(args.PackageName, args.Version, args.GitUrl));
+			installedPackages.Packages.Add(new InstalledPackage(args.PackageName, args.Version, args.GitUrl));
 
 			InstalledPackages.SetValue(installedPackages);
 			IsWorking.SetValue(false);

--- a/Editor/UI/Stores/PackageStore.cs
+++ b/Editor/UI/Stores/PackageStore.cs
@@ -66,7 +66,7 @@ namespace DUCK.PackageManager.Editor.UI.Stores
 		{
 			var args = (InstallPackageArgs) obj.Payload;
 			IsWorking.SetValue(true);
-			Operation.SetValue("Installing " + args.Package.Name + "...");
+			Operation.SetValue("Installing " + args.PackageName + "...");
 		}
 
 		private void HandlePackageInstallationComplete(Action obj)
@@ -75,7 +75,7 @@ namespace DUCK.PackageManager.Editor.UI.Stores
 
 			var installedPackages = InstalledPackages.Value;
 			installedPackages.Packages.Add(
-				new InstalledPackage(args.Package.Name, args.Version, args.Package.GitUrl));
+				new InstalledPackage(args.PackageName, args.Version, args.GitUrl));
 
 			InstalledPackages.SetValue(installedPackages);
 			IsWorking.SetValue(false);

--- a/Editor/UI/Styles/Colors.cs
+++ b/Editor/UI/Styles/Colors.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.Experimental.UIElements.StyleSheets;
 
 namespace DUCK.PackageManager.Editor.UI.Styles
 {
@@ -14,6 +15,7 @@ namespace DUCK.PackageManager.Editor.UI.Styles
 
 		public static readonly Color packageRowBackground = C("#878787");
 		public static readonly Color packageRowText = C("#2D2D2D");
+		public static readonly Color errorText = C("#DD0000");
 
 		private static Color C(string hex)
 		{


### PR DESCRIPTION
Now has the ability to add a custom package using any git url with optional version.

Right now the only restriction is it must be https url and the name cannot be taken by one of the installed packages. We probably want to also stop name collisions with duck packages