### PR TITLE
Dev sync project page

### DIFF
--- a/Editor/Data/PackageListStatus.cs
+++ b/Editor/Data/PackageListStatus.cs
@@ -1,9 +1,15 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace DUCK.PackageManager.Editor.Data
 {
 	internal class PackageListStatus
 	{
+		public bool IsProjectUpToDate
+		{
+			get { return packages.All(p => !p.IsMissing && !p.IsOnWrongVersion); }
+		}
+
 		private List<PackageStatus> packages;
 		public List<PackageStatus> Packages
 		{
@@ -21,5 +27,11 @@ namespace DUCK.PackageManager.Editor.Data
 		public string PackageName { get; set; }
 		public bool IsMissing { get; set; }
 		public bool IsOnWrongVersion { get; set; }
+
+		public override string ToString()
+		{
+			return PackageName + " is " +
+				(IsMissing ? "not installed." : (IsOnWrongVersion ? "on the wrong version." : "ok."));
+		}
 	}
 }

--- a/Editor/Data/PackageListStatus.cs
+++ b/Editor/Data/PackageListStatus.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace DUCK.PackageManager.Editor.Data
+{
+	internal class PackageListStatus
+	{
+		private List<PackageStatus> packages;
+		public List<PackageStatus> Packages
+		{
+			get { return packages; }
+		}
+
+		public PackageListStatus()
+		{
+			packages = new List<PackageStatus>();
+		}
+	}
+
+	internal class PackageStatus
+	{
+		public string PackageName { get; set; }
+		public bool IsMissing { get; set; }
+		public bool IsOnWrongVersion { get; set; }
+	}
+}

--- a/Editor/Data/PackageListStatus.cs
+++ b/Editor/Data/PackageListStatus.cs
@@ -27,6 +27,8 @@ namespace DUCK.PackageManager.Editor.Data
 		public string PackageName { get; set; }
 		public bool IsMissing { get; set; }
 		public bool IsOnWrongVersion { get; set; }
+		public string RequiredVersion { get; set; }
+		public string GitUrl { get; set; }
 
 		public override string ToString()
 		{

--- a/Editor/Data/PackageListStatus.cs.meta
+++ b/Editor/Data/PackageListStatus.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ce9e16a2a9f8499fa2159e85e0557698
+timeCreated: 1528814789

--- a/Editor/Git/CheckoutSubmoduleTask.cs
+++ b/Editor/Git/CheckoutSubmoduleTask.cs
@@ -7,7 +7,7 @@
 		public CheckoutSubmoduleTask(string installDirectory, string version) :
 			base(string.Format(COMMAND, version))
 		{
-			workingDirectory = installDirectory;
+			WorkingDirectory = installDirectory;
 		}
 	}
 }

--- a/Editor/Git/GetGitBranchOrTagTask.cs
+++ b/Editor/Git/GetGitBranchOrTagTask.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using DUCK.PackageManager.Editor.Data;
+using DUCK.PackageManager.Editor.Tasks;
+
+namespace DUCK.PackageManager.Editor.Git
+{
+	internal class GetGitBranchOrTagTask : ITask
+	{
+		public string Result { get; private set; }
+
+		private readonly InstalledPackage package;
+
+		public GetGitBranchOrTagTask(InstalledPackage package)
+		{
+			this.package = package;
+		}
+
+		public void Execute(Action onComplete = null)
+		{
+			var workingDirectory = Settings.AbsolutePackagesDirectoryPath + package.Name;
+
+			var symbolic = new GitTask("symbolic-ref -q --short HEAD");
+			symbolic.WorkingDirectory = workingDirectory;
+			symbolic.Execute(() =>
+			{
+				if (symbolic.ReceivedError || symbolic.StdOut.Count == 0)
+				{
+					var tags = new GitTask("describe --tags --exact-match");
+					tags.WorkingDirectory = workingDirectory;
+					tags.Execute(() =>
+					{
+						Result = tags.StdOut[0];
+						if (onComplete != null) onComplete();
+					});
+					return;
+				}
+
+				Result = symbolic.StdOut[0];
+				if (onComplete != null) onComplete();
+			});
+		}
+	}
+}

--- a/Editor/Git/GetGitBranchOrTagTask.cs.meta
+++ b/Editor/Git/GetGitBranchOrTagTask.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7216ae5c32384a10899d0fa878eed101
+timeCreated: 1528813568

--- a/Editor/UI/ActionTypes.cs
+++ b/Editor/UI/ActionTypes.cs
@@ -22,5 +22,8 @@
 		public const string SWITCH_PACKAGE_VERSION_FAILED = "switch-package-version-failed";
 
 		public const string CHANGE_TAB_PAGE = "change-tab-page";
+
+		public const string COMPILE_PACKAGE_LIST_STATUS_STARTED = "compile-package-list-status-started";
+		public const string COMPILE_PACKAGE_LIST_STATUS_COMPLETE = "compile-package-list-status-complete";
 	}
 }

--- a/Editor/UI/Actions.cs
+++ b/Editor/UI/Actions.cs
@@ -151,7 +151,7 @@ namespace DUCK.PackageManager.Editor.UI
 				packageStatus.PackageName = package.Name;
 				packageListStatus.Packages.Add(packageStatus);
 				var packageDirectory = Settings.AbsolutePackagesDirectoryPath + package.Name;
-				if (!File.Exists(packageDirectory))
+				if (!Directory.Exists(packageDirectory))
 				{
 					packageStatus.IsMissing = true;
 					continue;
@@ -160,11 +160,21 @@ namespace DUCK.PackageManager.Editor.UI
 				var task = new GetGitBranchOrTagTask(package);
 				var packageVersion = package.Version;
 				tasks.Add(task);
-				tasks.Add(() => { packageStatus.IsOnWrongVersion = task.Result != packageVersion; });
+				tasks.Add(() =>
+				{
+					packageStatus.IsOnWrongVersion = task.Result != packageVersion;
+				});
 			}
 
 			tasks.Execute(() =>
 			{
+				Debug.Log("Project package status");
+
+				foreach (var package in packageListStatus.Packages)
+				{
+					Debug.Log(package);
+				}
+
 				Dispatcher.Dispatch(ActionTypes.COMPILE_PACKAGE_LIST_STATUS_COMPLETE,
 					packageListStatus);
 			});

--- a/Editor/UI/Components/SyncProject/SyncProjectPage.cs
+++ b/Editor/UI/Components/SyncProject/SyncProjectPage.cs
@@ -21,7 +21,7 @@ namespace DUCK.PackageManager.Editor.UI.SyncProject
 			syncButton.Padding(8);
 			Add(syncButton);
 
-			// Working
+			//
 		}
 
 		private void HandleSyncButtonClicked()

--- a/Editor/UI/Components/SyncProject/SyncProjectPage.cs
+++ b/Editor/UI/Components/SyncProject/SyncProjectPage.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using DUCK.PackageManager.Editor.Git;
-using DUCK.PackageManager.Editor.Tasks;
-using DUCK.PackageManager.Editor.UI.Utils;
-using UnityEngine;
+﻿using DUCK.PackageManager.Editor.UI.Utils;
 using UnityEngine.Experimental.UIElements;
 using UnityEngine.Experimental.UIElements.StyleEnums;
 
@@ -20,13 +16,11 @@ namespace DUCK.PackageManager.Editor.UI.SyncProject
 			syncButton.text = "Sync Packages";
 			syncButton.Padding(8);
 			Add(syncButton);
-
-			//
 		}
 
 		private void HandleSyncButtonClicked()
 		{
-
+			Actions.CompilePackageListStatus();
 		}
 	}
 }

--- a/Editor/UI/Components/SyncProject/SyncProjectPage.cs
+++ b/Editor/UI/Components/SyncProject/SyncProjectPage.cs
@@ -1,5 +1,8 @@
-﻿using DUCK.PackageManager.Editor.UI.Components;
+﻿using System;
+using DUCK.PackageManager.Editor.Git;
+using DUCK.PackageManager.Editor.Tasks;
 using DUCK.PackageManager.Editor.UI.Utils;
+using UnityEngine;
 using UnityEngine.Experimental.UIElements;
 using UnityEngine.Experimental.UIElements.StyleEnums;
 
@@ -18,11 +21,12 @@ namespace DUCK.PackageManager.Editor.UI.SyncProject
 			syncButton.Padding(8);
 			Add(syncButton);
 
-			Add(new Overlay(new LoadingIndicator("Coming Soon")));
+			// Working
 		}
 
 		private void HandleSyncButtonClicked()
 		{
+
 		}
 	}
 }

--- a/Editor/UI/Components/SyncProject/SyncProjectPage.cs
+++ b/Editor/UI/Components/SyncProject/SyncProjectPage.cs
@@ -1,26 +1,52 @@
-﻿using DUCK.PackageManager.Editor.UI.Utils;
+﻿using DUCK.PackageManager.Editor.UI.Flux.Components;
+using DUCK.PackageManager.Editor.UI.Stores;
+using DUCK.PackageManager.Editor.UI.Utils;
 using UnityEngine.Experimental.UIElements;
 using UnityEngine.Experimental.UIElements.StyleEnums;
 
 namespace DUCK.PackageManager.Editor.UI.SyncProject
 {
-	internal class SyncProjectPage : VisualElement
+	internal class SyncProjectPage : StateBoundComponent
 	{
+		private readonly PackageStore packages = RootStore.Instance.Packages;
+
+		private readonly Label upToDateText;
+		private readonly Button syncButton;
+
 		public SyncProjectPage()
 		{
 			style.flex = 1;
 			style.alignItems = Align.Center;
 			style.paddingTop = 32;
 
-			var syncButton = new Button(HandleSyncButtonClicked);
+			upToDateText = new Label();
+			upToDateText.text = "Your project is up to date.";
+			upToDateText.style.fontSize = 16;
+			upToDateText.Padding(8);
+
+			syncButton = new Button(HandleSyncButtonClicked);
 			syncButton.text = "Sync Packages";
 			syncButton.Padding(8);
-			Add(syncButton);
+
+			BindToState(packages.PackageListStatus);
+
+			Init();
 		}
 
 		private void HandleSyncButtonClicked()
 		{
-			Actions.CompilePackageListStatus();
+			Actions.SyncProjectEpic();
+		}
+
+		protected override VisualElement[] Render()
+		{
+			var isUpToDate = packages.PackageListStatus.Value != null && packages.PackageListStatus.Value.IsProjectUpToDate;
+
+			return new VisualElement[]
+			{
+				isUpToDate ? null : syncButton,
+				isUpToDate ? upToDateText : null,
+			};
 		}
 	}
 }

--- a/Editor/UI/Stores/PackageStore.cs
+++ b/Editor/UI/Stores/PackageStore.cs
@@ -10,6 +10,7 @@ namespace DUCK.PackageManager.Editor.UI.Stores
 		public IState<bool> IsFetchingPackages { get; private set; }
 		public IState<AvailablePackageList> AvailablePackages { get; set; }
 		public IState<InstalledPackageList> InstalledPackages { get; set; }
+		public IState<PackageListStatus> PackageListStatus { get; set; }
 		public IState<string> Error { get; set; }
 		public IState<string> SearchQuery { get; set; }
 
@@ -21,6 +22,7 @@ namespace DUCK.PackageManager.Editor.UI.Stores
 			IsFetchingPackages = store.CreateState(false);
 			AvailablePackages = store.CreateState<AvailablePackageList>(null);
 			InstalledPackages = store.CreateState(new InstalledPackageList());
+			PackageListStatus = store.CreateState<PackageListStatus>(null);
 			Error = store.CreateState<string>(null);
 			SearchQuery = store.CreateState<string>(null);
 			IsWorking = store.CreateState(false);
@@ -35,9 +37,10 @@ namespace DUCK.PackageManager.Editor.UI.Stores
 			store.Subscribe(ActionTypes.REMOVE_PACKAGE_STARTED, HandleRemovePackageStarted);
 			store.Subscribe(ActionTypes.REMOVE_PACKAGE_COMPLETE, HandleRemovePackageComplete);
 			store.Subscribe(ActionTypes.READ_PACKAGES_JSON, HandleReadPackagesJson);
-
 			store.Subscribe(ActionTypes.SWITCH_PACKAGE_VERSION_STARTED, HandleSwitchPackageVersionStarted);
 			store.Subscribe(ActionTypes.SWITCH_PACKAGE_VERSION_COMPLETE, HandleSwitchPackageVersionComplete);
+			store.Subscribe(ActionTypes.COMPILE_PACKAGE_LIST_STATUS_STARTED, HandleCompletPackageListStatusStarted);
+			store.Subscribe(ActionTypes.COMPILE_PACKAGE_LIST_STATUS_COMPLETE, HandleCompletPackageListStatusComplete);
 		}
 
 		private void HandleRequestPackageListStarted(Action obj)
@@ -124,6 +127,21 @@ namespace DUCK.PackageManager.Editor.UI.Stores
 		{
 			var jsonText = JsonUtility.ToJson(InstalledPackages.Value, true);
 			File.WriteAllText(Settings.AbsolutePackagesJsonFilePath, jsonText);
+		}
+
+		private void HandleCompletPackageListStatusStarted(Action obj)
+		{
+			PackageListStatus.SetValue(null);
+			IsWorking.SetValue(true);
+			Operation.SetValue("Compiling status of each package");
+		}
+
+		private void HandleCompletPackageListStatusComplete(Action obj)
+		{
+			IsWorking.SetValue(false);
+			Operation.SetValue(null);
+
+			PackageListStatus.SetValue((PackageListStatus) obj.Payload);
 		}
 	}
 }


### PR DESCRIPTION
Known issues:
* Tasks: if one fails the whole chain fails. Ok in most situations but on a sync, if one package fails we kinda wanna keep going on the others.
* If a package failed to sync, it would be nice to inform the user, and how they can go fix it manually.
* Output: Git tasks often output to std_err, at the moment we pipe all that into the console. it's not ideal.
* The sync action, is a compound or epic action made up of other sub actions. It only dispatches on the sub action (CompiliePackageStatus), we should probably manipulate some state to show progress during the whole task.
* There is no state change in the store to indicate the results of the sync (right now it always assumes it completed, theres no concept of success fail etc.) the user feedback for that is all console message, and it's pretty noisy.